### PR TITLE
Removing xla submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "deps/xla"]
-	path = deps/xla
-	url = git@github.com:pytorch/xla.git
-    ignore = dirty
 [submodule "deps/fairseq"]
 	path = deps/fairseq
 	url = git@github.com:pytorch-tpu/fairseq.git

--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -58,7 +58,7 @@ import collections
 from datetime import datetime
 from utils import initialize_path
 
-initialize_path('xla', 'fairseq')
+initialize_path('fairseq')
 
 import torch
 


### PR DESCRIPTION
If we assume people run this code on a vm where torch_xla is already built, then having xla as a submodule here is not needed.

This confuses the user. It's nice to have this submodule when developing, since we can edit code and see effect immediately pretty easily. For that functionality, I cut the `dev` branch.