### PR TITLE
Enabling variable input shapes

### DIFF
--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -213,7 +213,7 @@ def main_tpu(args):
         print(log_step('training', device, i, tracker=tracker))
       _log_output = trainer.train_step(samples)
       xm.optimizer_step(trainer.optimizer)
-      tracker.add(len(samples) * args.max_sentences)  # n_batches * batch_size
+      tracker.add(sum(sample['nsentences'] for sample in samples))
     stats = fairseq_train.get_training_stats(trainer)
     return tracker, stats
 

--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -7,6 +7,44 @@ This file mimics pytorch/fairseq/train.py, but contains some changes that work
 ```bash
 export XRT_TPU_CONFIG="tpu_worker;0;$TPU_IP_ADDRESS:8470"
 
+python fairseq_train_tpu.py \
+  $data_path \
+  --arch=transformer_vaswani_wmt_en_de_big \
+  --max-target-positions=64 \
+  --no-save \
+  --attention-dropout=0.1 \
+  --no-progress-bar \
+  --criterion=label_smoothed_cross_entropy \
+  --source-lang=en \
+  --lr-scheduler=inverse_sqrt \
+  --min-lr 1e-09 \
+  --skip-invalid-size-inputs-valid-test \
+  --target-lang=de \
+  --label-smoothing=0.1 \
+  --update-freq=1 \
+  --optimizer adam \
+  --adam-betas '(0.9, 0.98)' \
+  --warmup-init-lr 1e-07 \
+  --lr 0.0005 \
+  --warmup-updates 4000 \
+  --share-all-embeddings \
+  --dropout 0.3 \
+  --weight-decay 0.0 \
+  --valid-subset=valid \
+  --max-epoch=50 \
+    --input_shapes=512x16,256x32,128x64 \
+    --num_cores=8 \
+    --metrics_debug \
+    --log_steps=100
+```
+
+Here, TPU specific flags are:
+
+    --input_shapes=512x16,256x32,128x64 \
+    --num_cores=8 \
+    --metrics_debug \
+    --log_steps=100
+
 """
 
 import argparse
@@ -141,7 +179,6 @@ def parse_args():
   FLAGS.input_shapes = parse_input_shapes(FLAGS)
   # XXX (taylanbil): do we ever have more than 2 dimensions in fairseq?
   FLAGS.max_source_positions = FLAGS.input_shapes[-1][1]
-  # XXX (taylanbil): what about `max_target_positions`?
   return FLAGS
 
 

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ Utility functions shared by different runners in this repo
 
 import os
 import sys
+from datetime import datetime
 
 
 def initialize_path(*deps):


### PR DESCRIPTION
We were forcing static input shapes, as that is generally the rule of
thumb, but it turned out that allowing 2 or more input shapes may
actually be better in the end. It causes bigger overhead in the start,
but we're not wasting as many flops as a static shape;

If we always force 128 sentences and 64 tokens in one batch, then
sentences shorter than 64 tokens will be padded to 64.
However, if we allow 128x64 and 256x32 inputs, we both

* sometimes process more records in one step
* waste less flops because we have much less pads in the input.

In this pr, I:
* updated example command in the docstring
* overrode `fairseq/data/data_utils.batch_by_size` w/ tpu version
* changed `collate_tokens_tpu`
* input shapes are now controlled by --input_shapes
* changed `parse_args` accordingly. We now error when gpu input control
  flags are enabled.
* cleaned the log_step function
* added missing import in utils.py