### PR TITLE
relative url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "deps/fairseq"]
 	path = deps/fairseq
-	url = git@github.com:pytorch-tpu/fairseq.git
+	url = ../fairseq.git
 	branch = xla
     ignore = dirty


### PR DESCRIPTION
This would enable git clone --recursive w/ the http url for the examples repo.