### PR TITLE
Get pad length from cli arg and batch size as opposed to inferring from max num tokens in batch

### DIFF
--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -96,12 +96,14 @@ def collate_tokens_tpu(values,
                        eos_idx=None,
                        left_pad=False,
                        move_eos_to_beginning=False):
-  size = max(v.size(0) for v in values)
   for batch_size, padlen in INPUT_SHAPES:
-    if padlen < size:
-      continue
-    size = padlen
-    break
+    if len(values) == batch_size:
+      size = padlen
+      break
+  else:
+    raise IndexError(
+        'Encountered values with an invalid length {}, input shapes were {}'
+        .format(len(values), input_shapes))
   res = values[0].new(len(values), size).fill_(pad_idx)
 
   def copy_tensor(src, dst):


### PR DESCRIPTION
### Problem description:

* when batching samples, fairseq looks at max number of tokens between [source and target](https://github.com/pytorch-tpu/fairseq/blob/master/fairseq/data/language_pair_dataset.py#L189)
* when padding samples, it pads [source](https://github.com/pytorch-tpu/fairseq/blob/master/fairseq/data/language_pair_dataset.py#L28) and [target](https://github.com/pytorch-tpu/fairseq/blob/master/fairseq/data/language_pair_dataset.py#L38) separately.
* rest is explained by an example:
  * let's say `--input_shapes 10x20 40x5`
  * there will be a batch with at most 5 tokens in source, but 6 tokens in target
  * so fairseq will produce a batch with 10 sentences (because 6 tokens wont fit to 40x5)
  * but the padded input will be 10x5, since the source sentences have max 5 tokens.
  * we produced an input with shape 10x5 -> more compilations, etc.

### Solution

When determining the padding length, do not use the input's number of tokens, but use the given batch's size, so we know we produce one of the input shapes in the cli arg.