### PR TITLE
Validating input shapes argument.

### DIFF
--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -198,6 +198,14 @@ def parse_input_shapes(input_shapes_arg):
       shape.replace('*', 'x').split('x') for shape in input_shapes_arg)
   input_shapes = [list(map(int, shape)) for shape in input_shapes]
   input_shapes.sort(key=lambda shape: shape[1])
+  errmsg = (
+      'Invalid --input_shapes. Batch sizes (dimension 1) need to increase as '
+      'num_tokens (dimension 2) decrease. e.g. 16x128 32x64 64x32'
+  )
+  assert all(
+      shape_prev[0] < shape_next[0]
+      for shape_prev, shape_next in zip(input_shapes, input_shapes[1:])), errmsg
+
   return input_shapes
 
 


### PR DESCRIPTION
With https://github.com/pytorch-tpu/examples/pull/23, we're now reliant on `--input_shapes` having unique batch_sizes. This PR validates the input before continuing and running into a hard to decipher error.