### PR TITLE
During validation of input shapes, early return for single input shape

### DIFF
--- a/fairseq_train_tpu.py
+++ b/fairseq_train_tpu.py
@@ -197,6 +197,8 @@ def parse_input_shapes(input_shapes_arg):
   input_shapes = (
       shape.replace('*', 'x').split('x') for shape in input_shapes_arg)
   input_shapes = [list(map(int, shape)) for shape in input_shapes]
+  if len(input_shapes) == 1:
+    return input_shapes
   input_shapes.sort(key=lambda shape: shape[1])
   errmsg = (
       'Invalid --input_shapes. Batch sizes (dimension 1) need to increase as '


### PR DESCRIPTION
Single input shape breaks the assert because any() returns false when the arg is empty. This pr fixes it.